### PR TITLE
[Rust] prevent catastrophic backtracking on the identifier pattern

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -6,7 +6,7 @@ file_extensions:
   - rs
 scope: source.rust
 variables:
-  identifier: '(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)'
+  identifier: '(?:(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)(?![_[:alnum:]]))' # include a negative lookahead at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
   escaped_byte: '\\(x\h{2}|n|r|t|0|"|''|\\)'
   escaped_char: '\\(x\h{2}|n|r|t|0|"|''|\\|u\{\h{1,6}\})'
   int_suffixes: 'i8|i16|i32|i64|isize|u8|u16|u32|u64|usize'
@@ -624,8 +624,7 @@ contexts:
       pop: true
 
   impl-for:
-    # inline {{identifier}} and use possesive quantifiers to avoid catastrophic backtracking in non-Sublime implementations
-    - match: '(?=\s*(?:::|[[:alpha:]][_[:alnum:]]*+|_[_[:alnum:]]++|\$|<)++(<.*?>)?\s+for\s+)'
+    - match: '(?=\s*(?:::|{{identifier}}|\$|<)++(<.*?>)?\s+for\s+)'
       set:
         - meta_scope: meta.impl.rust
         - include: comments

--- a/Rust/syntax_test_rust.rs
+++ b/Rust/syntax_test_rust.rs
@@ -937,3 +937,7 @@ pub const FOO: Option<[i32; 1]> = Some([1]);
 //                        ^ punctuation.separator
 //                          ^ constant.numeric
 //                           ^ punctuation.definition.group.end.rust
+
+impl ApplicationPreferenceseeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee {
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.impl.rust
+}


### PR DESCRIPTION
this prevents catastrophic backtracking for backtracking regex engines like Oniguruma by removing (unwanted) possible backtracking states. It does this by adding a negative lookahead to the end of the "identifier" pattern, to ensure that all possible identifier characters are consumed. This also ensures that there is no performance regression in ST's sregex engine, by avoiding unsupported features like atomic groups / possessive quantifiers.